### PR TITLE
fixed autoloading

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,12 +27,8 @@
     },
     "autoload": {
         "psr-4" : {
-            "Sabre\\ResourceLocator\\" : "lib/",
-            "Sabre\\Uri\\" : "../Uri/lib/"
-        },
-        "files" : [
-            "../Uri/lib/functions.php"
-        ]
+            "Sabre\\ResourceLocator\\" : "lib/"
+        }
     },
     "require-dev": {
         "squizlabs/php_codesniffer": "*",


### PR DESCRIPTION
Was running into autoloading issues with the current composer.json.

```
Warning: require(/Users/foo/fruux/sabre-resourcelocator/../Uri/lib/functions.php): failed to open stream: No such file or directory in /Users/foo/fruux/sabre-resourcelocator/vendor/composer/autoload_real.php on line 58

Call Stack:
    0.0003     254552   1. {main}() /Users/foo/fruux/sabre-resourcelocator/examples.php:0
    0.0004     256296   2. include('/Users/foo/fruux/sabre-resourcelocator/vendor/autoload.php') /Users/foo/fruux/sabre-resourcelocator/examples.php:12
    0.0005     269528   3. ComposerAutoloaderInit3fce26e2c4e873d98624af94248a7212::getLoader() /Users/foo/fruux/sabre-resourcelocator/vendor/autoload.php:7
    0.0025     554760   4. composerRequire3fce26e2c4e873d98624af94248a7212() /Users/foo/fruux/sabre-resourcelocator/vendor/composer/autoload_real.php:49


Fatal error: require(): Failed opening required '/Users/foo/fruux/sabre-resourcelocator/../Uri/lib/functions.php' (include_path='/Users/foo/fruux/sabre-resourcelocator/vendor/phpunit/php-text-template:/Users/foo/fruux/sabre-resourcelocator/vendor/phpunit/php-timer:/Users/foo/fruux/sabre-resourcelocator/vendor/phpunit/php-file-iterator:.:/usr/lib/php/pear') in /Users/foo/fruux/sabre-resourcelocator/vendor/composer/autoload_real.php on line 58

Call Stack:
    0.0003     254552   1. {main}() /Users/foo/fruux/sabre-resourcelocator/examples.php:0
    0.0004     256296   2. include('/Users/foo/fruux/sabre-resourcelocator/vendor/autoload.php') /Users/foo/fruux/sabre-resourcelocator/examples.php:12
    0.0005     269528   3. ComposerAutoloaderInit3fce26e2c4e873d98624af94248a7212::getLoader() /Users/foo/fruux/sabre-resourcelocator/vendor/autoload.php:7
    0.0025     554760   4. composerRequire3fce26e2c4e873d98624af94248a7212() /Users/foo/fruux/sabre-resourcelocator/vendor/composer/autoload_real.php:49
```
